### PR TITLE
Adding Enabled Field and Remove Schedule Config

### DIFF
--- a/freshdesk-article-connector/freshdesk/km/connector/freshdesk_helpArticleConnector.json
+++ b/freshdesk-article-connector/freshdesk/km/connector/freshdesk_helpArticleConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "60221",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -179,9 +180,5 @@
       "header": "Folder Name",
       "subfieldPath": []
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }


### PR DESCRIPTION
Schedule Configurations will soon be removed from all push connectors
with added validation preventing it. Adding enabled flag which will
be used when pushing data - the enabled flag uses the boolean from
use source schedule
